### PR TITLE
Refactor/move pagination interface from core paste

### DIFF
--- a/packages/challenges/src/core/domain/Pagination.interface.ts
+++ b/packages/challenges/src/core/domain/Pagination.interface.ts
@@ -1,0 +1,7 @@
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalItems: number;
+  containsNextPage: boolean;
+}

--- a/packages/challenges/src/modules/answers/repositories/IAnswer.repository.ts
+++ b/packages/challenges/src/modules/answers/repositories/IAnswer.repository.ts
@@ -1,5 +1,5 @@
+import { Pagination } from 'src/core/domain/Pagination.interface';
 import { PaginationInput } from 'src/modules/challenges/dto/pagination.input';
-import { IPagination } from 'src/modules/challenges/interfaces/IPagination.interface';
 import { Status } from '../enums/Status.enum';
 import { IAnswer } from '../interfaces/IAnswer.interface';
 
@@ -22,7 +22,7 @@ export interface IFilter {
 
 export interface IListAllResponse {
   answers: IAnswer[];
-  pagination: IPagination;
+  pagination: Pagination;
 }
 
 export interface IAnswerRepository {

--- a/packages/challenges/src/modules/answers/typesObjects/PaginatedAnswers.typeObject.ts
+++ b/packages/challenges/src/modules/answers/typesObjects/PaginatedAnswers.typeObject.ts
@@ -1,12 +1,13 @@
 import { ObjectType, Field } from '@nestjs/graphql';
 import { Answer } from '../entities/Answer.entity';
-import { Pagination } from '../../challenges/typesObjects/pagination.typeObject';
+import { PaginationTypeObject } from '../../challenges/typesObjects/pagination.typeObject';
+import { Pagination } from 'src/core/domain/Pagination.interface';
 
 @ObjectType()
 export class PaginatedAnswers {
   @Field(() => [Answer])
   answers: Answer[];
 
-  @Field(() => Pagination)
+  @Field(() => PaginationTypeObject)
   pagination: Pagination;
 }

--- a/packages/challenges/src/modules/answers/useCases/listAnswers/ListAnswers.useCase.ts
+++ b/packages/challenges/src/modules/answers/useCases/listAnswers/ListAnswers.useCase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { Pagination } from 'src/core/domain/Pagination.interface';
 import { PaginationInput } from 'src/modules/challenges/dto/pagination.input';
-import { IPagination } from 'src/modules/challenges/interfaces/IPagination.interface';
 import {
   IFilter,
   IListAllResponse,
@@ -8,7 +8,7 @@ import {
 import { AnswerRepository } from '../../repositories/prisma/Answer.repository';
 
 interface IListAnswersInput {
-  pagination?: Partial<IPagination>;
+  pagination?: Partial<Pagination>;
   filter?: IFilter;
 }
 @Injectable()

--- a/packages/challenges/src/modules/challenges/interfaces/IPagination.interface.ts
+++ b/packages/challenges/src/modules/challenges/interfaces/IPagination.interface.ts
@@ -1,7 +1,0 @@
-export interface IPagination {
-  page: number;
-  pageSize: number;
-  totalPages: number;
-  totalItems: number;
-  containsNextPage: boolean;
-}

--- a/packages/challenges/src/modules/challenges/repositories/IChallenge.repository.ts
+++ b/packages/challenges/src/modules/challenges/repositories/IChallenge.repository.ts
@@ -1,10 +1,10 @@
+import { Pagination } from 'src/core/domain/Pagination.interface';
 import { PaginationInput } from '../dto/pagination.input';
 import { IChallenge } from '../interfaces/IChallenge.interface';
-import { IPagination } from '../interfaces/IPagination.interface';
 
 interface IListAllResponse {
   challenges: IChallenge[];
-  pagination: IPagination;
+  pagination: Pagination;
 }
 export interface IChallengeRepository {
   create(challenge: Partial<IChallenge>): Promise<IChallenge>;

--- a/packages/challenges/src/modules/challenges/typesObjects/paginated-challenges.typeObject.ts
+++ b/packages/challenges/src/modules/challenges/typesObjects/paginated-challenges.typeObject.ts
@@ -1,12 +1,13 @@
 import { ObjectType, Field } from '@nestjs/graphql';
+import { Pagination } from 'src/core/domain/Pagination.interface';
 import { Challenge } from '../entities/challenge.entity';
-import { Pagination } from './pagination.typeObject';
+import { PaginationTypeObject } from './pagination.typeObject';
 
 @ObjectType()
 export class PaginatedChallenges {
   @Field(() => [Challenge])
   challenges: Challenge[];
 
-  @Field(() => Pagination)
+  @Field(() => PaginationTypeObject)
   pagination: Pagination;
 }

--- a/packages/challenges/src/modules/challenges/typesObjects/pagination.typeObject.ts
+++ b/packages/challenges/src/modules/challenges/typesObjects/pagination.typeObject.ts
@@ -1,8 +1,8 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql';
-import { IPagination } from '../interfaces/IPagination.interface';
+import { Pagination } from 'src/core/domain/Pagination.interface';
 
 @ObjectType()
-export class Pagination implements IPagination {
+export class PaginationTypeObject implements Pagination {
   @Field(() => Int)
   page: number;
 

--- a/packages/challenges/src/modules/challenges/useCase/listChallenges/ListChallenges.useCase.ts
+++ b/packages/challenges/src/modules/challenges/useCase/listChallenges/ListChallenges.useCase.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Pagination } from 'src/core/domain/Pagination.interface';
 import { PaginationInput } from '../../dto/pagination.input';
 import { ChallengeRepository } from '../../repositories/prisma/Challenge.repository';
 
@@ -15,7 +16,7 @@ export class ListChallengesUseCase {
     const DEFAULT_PAGINATION = {
       page: 1,
       pageSize: 10,
-    } as PaginationInput;
+    } as Pagination;
 
     const challenges = await this.challengeRepository.listAll(
       {


### PR DESCRIPTION
Alem de mover a interface `Pagination` foi alterado o nome do `Type Object` que estava conflitando com o nome da interface.

**obs:** Seria bom revisar os nomes das variáveis